### PR TITLE
police: add the force parameter

### DIFF
--- a/lib/police.js
+++ b/lib/police.js
@@ -69,6 +69,13 @@ police.start = function (argv, callback) {
     }
 
     /*
+     * Set force parameter
+     */
+    if (argv.force || argv.f) {
+      police.force = true;
+    }
+
+    /*
      * Reads a local file and checks it
      */
     if (argv.l) {

--- a/lib/police/check.js
+++ b/lib/police/check.js
@@ -110,6 +110,10 @@ check.npm = function (dep, callback) {
     if (res.statusCode==404) {
       police.winston.warn('Module is MIA (missing in action)'.red.bold);
       police.winston.warn(res.request.uri.href.red);
+      if (police.force) {
+        callback();
+        return;
+      }
       callback(1);
     } else {
       body = JSON.parse(body);

--- a/lib/police/help.js
+++ b/lib/police/help.js
@@ -51,6 +51,7 @@ help.usage = [
   'Miscellaneous police flags'.cyan.bold,
   '',
 
+  '  --force, -f          Continue running even if errors are encountered',
   '  --destroy, -d        Destroys exisiting authentication',
   '  --conf [FILE]        Sets the configuraiton file to be used',
   '  --version, -v        Displays version',


### PR DESCRIPTION
In some cases you may have npm modules that aren't in the public npm
module database. Add the -f flag to continue running even if that is the
case.
