### PR TITLE
Suggestions shouldn't show as an error.

### DIFF
--- a/lib/police/check.js
+++ b/lib/police/check.js
@@ -69,7 +69,7 @@ check.suggest = function (pkg, local, callback) {
   if (suggestions.length==0) {
     police.winston.info('  ✓'.green.bold + ' No suggestions');
   } else {
-    police.winston.info('  ✗'.red.bold + ' Suggest adding ' + suggestions.join(', '));
+    police.winston.info('  -'.yellow.bold + ' Suggest adding ' + suggestions.join(', '));
   }
   if (police.update) {
     pkg.dependencies = check.dependencies;


### PR DESCRIPTION
A red "X" is normally associated with errors, a suggestion should not be an error?
