### PR TITLE
defaults; non-SSL registry, local opt package.json

### DIFF
--- a/lib/police.js
+++ b/lib/police.js
@@ -101,14 +101,14 @@ police.start = function (argv, callback) {
     /*
      * Set registry parameter
      */
-    police.registry = argv.registry || police.config.get('registry') || 'https://registry.npmjs.org/'
+    police.registry = argv.registry || police.config.get('registry') || 'http://registry.npmjs.org/'
 
     /*
      * Reads a local file and checks it
      */
     if (argv.l) {
       maincmd = false;
-      police.check.local(argv.l);
+      police.check.local(argv.l !== true ? argv.l : 'package.json');
     }
 
     /*


### PR DESCRIPTION
this patch gets local to behave the same way it did for node 0.10.x as it did for 0.8.x
#19
